### PR TITLE
Only attempt to use the taskbar if it is supported

### DIFF
--- a/src/main/kotlin/dev/shota/decompiler/window/Window.kt
+++ b/src/main/kotlin/dev/shota/decompiler/window/Window.kt
@@ -36,7 +36,7 @@ object Window : JFrame() {
         title = "Decompiler"
         defaultCloseOperation = DISPOSE_ON_CLOSE
         val icon = ImageIcon(javaClass.classLoader.getResourceAsStream("icons/logo.png")?.readAllBytes()).image
-        if (Taskbar.getTaskbar().isSupported(Taskbar.Feature.ICON_IMAGE)) Taskbar.getTaskbar().iconImage = icon
+        if (Taskbar.isTaskbarSupported() && Taskbar.getTaskbar().isSupported(Taskbar.Feature.ICON_IMAGE)) Taskbar.getTaskbar().iconImage = icon
         iconImage = icon
         jMenuBar = Menu()
 


### PR DESCRIPTION
Some (mostly linux) platforms don't support TaskBars, so will throw an exception when trying to call `Taskbar.getTaskbar()`. Checking isTaskbarSupported first fixes this.